### PR TITLE
Service workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "mozilla-download": "^1.1.1",
     "nock": "^3.5.0",
     "node-sass": "^3.4.2",
-    "react-addons-test-utils": "^0.14.5",
+    "react-addons-test-utils": "0.14.5",
     "redux-mock-store": "0.0.3",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0",
@@ -53,7 +53,7 @@
   "dependencies": {
     "classnames": "2.2.1",
     "react": "0.14.5",
-    "react-dom": "0.14.3",
+    "react-dom": "0.14.5",
     "react-redux": "4.0.1",
     "redux": "3.0.5",
     "redux-logger": "2.2.1",

--- a/src/lib/registerServiceWorker.js
+++ b/src/lib/registerServiceWorker.js
@@ -1,0 +1,16 @@
+module.exports = function registerServiceWorker() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('./sw.js', {scope: './'}).then(function (reg) {
+      if (reg.installing) {
+        console.log('Service worker installing');
+      } else if (reg.waiting) {
+        console.log('Service worker installed');
+      } else if (reg.active) {
+        console.log('Service worker active');
+      }
+    }).catch(function (error) {
+      // registration failed
+      console.log('Registration failed with ' + error);
+    });
+  }
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,8 @@
 // require('babel-polyfill');
 
+const registerServiceWorker = require('lib/registerServiceWorker');
+registerServiceWorker();
+
 const React = require('react');
 const ReactDOM = require('react-dom');
 const {combineReducers} = require('redux');

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,82 @@
+// I am a service worker for the remote newtab page.
+"use strict";
+
+// NOTE: To invalidate cached resources, change the version number below.
+const VERSION = '1';
+const CACHE_NAME = 'remote-newtab-v' + VERSION;
+
+self.addEventListener('install', function (event) {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(function (cache) {
+      return cache.addAll([
+        './',
+        './www/main.js',
+        './www/main.css',
+        './img/icon-gear.svg',
+        './img/magnifier.png',
+        './img/pin.svg',
+        './img/x.svg'
+      ]);
+    })
+  );
+});
+
+function networkFirst(evt) {
+  // Current browser implementations require waitUntil() to be called
+  // synchronously during the event dispatch.  In the future we should
+  // be able to move the evt.waitUntil() down to directly where we
+  // need it in the respondWith() async handling.
+  var waitUntilResolve;
+  evt.waitUntil(new Promise(function(resolve) {
+    waitUntilResolve = resolve;
+  }));
+
+  var cache;
+  evt.respondWith(caches.open(CACHE_NAME).then(function(c) {
+    cache = c;
+    return fetch(evt.request);
+  }).then(function(response) {
+    waitUntilResolve(cache.put(evt.request, response.clone()));
+    return response;
+  }).catch(function(e) {
+    return cache.match(evt.request);
+  }).then(function(response) {
+    // Always resolve the waitUntil promise. This is a no-op if we already
+    // resolved the promise with cache.put() above.
+    waitUntilResolve();
+    // Final fallback if we are offline and cached content isn't available.
+    return response || new Response('Offline and content unavailable.');
+  }));
+}
+
+addEventListener('fetch', function(evt) {
+  // TODO: Here we can skip any resources we don't want to cache.
+  // let skip = false;
+  // if (skip) {
+  //   return;
+  // }
+
+  // We check the network before the cache for a few reasons:
+  // * cache.addAll() will cache 404s, 500s, etc
+  // * for cross origin resources without CORS, we dont know the response code
+  // * the network has it's own HTTP caching that kicks in anyway
+  networkFirst(evt);
+});
+
+self.addEventListener('activate', function (event) {
+  // Claim the client that registered this service worker
+  event.waitUntil(self.clients.claim());
+
+  // Do some cache management. Remove caches no longer used.
+  event.waitUntil(
+    caches.keys().then(function (cacheNames) {
+      return Promise.all(
+        cacheNames.map(function (cacheName) {
+          if (cacheName !== CACHE_NAME) {
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+});


### PR DESCRIPTION
This incorporates the feedback from @marcoscaceres last time to always go to the network before the cache. It is easy to test. Load the page up. Stop the server. "soft" refresh or load the page again in a new tab.

r? @k88hudson 

PS. We might need to make some changes depending on how generated thumbs is implemented on the client.
